### PR TITLE
Basic background data about the ASLO Bulletin 19(1): 18 about pre-pri…

### DIFF
--- a/letter.md
+++ b/letter.md
@@ -17,7 +17,7 @@ date: 21 March 2017
         2. NIH: adoption of preprints in proposals - see [this](https://grants.nih.gov/grants/guide/notice-files/NOT-OD-17-050.html) recent NIH announcement
 2. Benefits of preprints
     1. To scientific community
-    2. To ASLO (are there any?)
+    2. To ASLO (are there any? not be offside with other societies and not have different policies for L&O and L&OL)
 4. Recommendations: 
     1. L&O should actively encourage authors to post preprints prior to L&O submission
     2. Any policy specifics? "No manuscripts with a DOI" seems to be the current policy - what is a better policy?

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ The purposes of this letter would be to:
 1. Inform Dr. Howarth (& the L&O advisory group) about the advantages of preprints
 2. Explain the process of preprints - what counts as a preprint, what doesn't
 3. Provide context, including how other fields are using preprints
-3. Specifically address what to do about Biogeosciences Discussions & similar journals (are there any others quite like it?)
+3. Specifically address what to do about Biogeosciences Discussions & similar journals (all the European Geophysical Union journals use the 'Discussions' model where submissions are given a doi and are open to public peeer-review in a multi-stage model, see (http://publications.copernicus.org/) . Also see page 18 of the [ASLO Bulletin 19(1)](http://aslo.org/bulletin/10_v19_i1.pdf#page=18) )
 
 # Format
 


### PR DESCRIPTION
Background here is:

- [http://aslo.org/bulletin/10_v19_i1.pdf#page=18]
- L&O had a reviewer ask during late 2009 about a Biogeosciences Discussions pre-print that was under review at L&O
- editorial board was unaware of EGU's change to multi-stage pre-print style review
- editorial board seemed unaware of pre-prints in general
- unclear nature of the EGU's Discussion paper that are not listed as 'rejected' caused concern for the editorial board
- IMHO, the portion of the editorial board opposed to the shift from paper-based publishing to online publishing (a shit from paper subscriptions to electronic subscriptions plus a a split from paper workflows to electronic workflows board) won the day
- from then on, all pre-prints were viewed as a 'barrier to publication'
- in the interim, many of our society journals now accept pre-prints and the new L&O Letters explicitly does: [L&O-Letters will consider submissions that have previously been made available, either on a preprint server like arXiv, bioRxiv, or PeerJ PrePrints](http://aslopubs.onlinelibrary.wiley.com/hub/journal/10.1002/(ISSN)2378-2242/about/author-guidelines.html)